### PR TITLE
send refreshToken via httpOnly cookie

### DIFF
--- a/__tests__/authController.tests.js
+++ b/__tests__/authController.tests.js
@@ -12,9 +12,228 @@ const passport = require('passport');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken')
 
+describe('authController', () => {
 
+  beforeEach( async () => {
 
-describe('authController.loginUser', () => {
+    tokens = await userModel.generateTokens({ user: { id: 1}})
+
+    accessToken = tokens.accessToken
+    refreshToken = tokens.refreshToken
+
+  })
+
+  afterEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  describe('logoutUser', () => {
+
+    beforeEach(async () => {
+  
+    })
+  
+    afterEach(() => {
+      jest.clearAllMocks();
+    })
+  
+    it('should return status 200 and log out a user and remove the associated refresh token assigned', async () => {
+  
+      // Setup
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return { 
+          id: 1, 
+          token: 'wWQEQQEGYTG345456234',
+          created_at: '',
+          updated_at: ''      
+        }
+      })
+  
+      jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
+        return {
+          success: true,
+          message: 'refreshToken successfully removed'
+        }
+      })
+  
+      jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
+        return {
+          user: { id: 1 },
+        }
+      })
+  
+      const returnStatus = 200
+      const returnSuccess = true
+      const returnMessage = 'Successfully logged out'
+  
+      // Execute
+      const res = await request(app)
+        .post(`/auth/logout`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .set('Cookie', `jwt=${refreshToken}`)
+  
+      // Assert
+      expect(res.status).toBe(returnStatus)
+  
+      expect(typeof res.body.status).toBe('number')
+      expect(typeof res.body.success).toBe('boolean')
+      expect(typeof res.body.message).toBe('string')
+  
+      expect(res.body.status).toEqual(returnStatus)
+      expect(res.body.success).toEqual(returnSuccess)
+      expect(res.body.message).toEqual(returnMessage)
+      
+    })
+  
+    it('should return status 200 and send a logout message if no refreshToken is found assigned to a user', async () => {
+  
+      // Setup
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return false
+      })
+  
+      jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
+        return {
+          success: false,
+          message: 'No refresh tokens were found matching supplied data'
+        }
+      })
+  
+      jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
+        return {
+          user: { id: 1 },
+        }
+      })
+  
+      const returnStatus = 200
+      const returnSuccess = true
+      const returnMessage = 'Successfully logged out'
+  
+      // Execute
+      const res = await request(app)
+        .post(`/auth/logout`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .set('Cookie', `jwt=${refreshToken}`)
+  
+      // Assert
+      expect(res.status).toBe(returnStatus)
+  
+      expect(typeof res.body.status).toBe('number')
+      expect(typeof res.body.success).toBe('boolean')
+      expect(typeof res.body.message).toBe('string')
+  
+      expect(res.body.status).toEqual(returnStatus)
+      expect(res.body.success).toEqual(returnSuccess)
+      expect(res.body.message).toEqual(returnMessage)
+      
+    })
+  
+    it('should return status 404 if no refresh token is sent', async () => {
+  
+      // Setup
+      let missingToken
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return { 
+          id: 1, 
+          token: 'wWQEQQEGYTG345456234',
+          created_at: '',
+          updated_at: ''      
+        }
+      })
+  
+      jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
+        return {
+          success: true,
+          message: 'refreshToken successfully removed'
+        }
+      })
+  
+      jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
+        return {
+          user: { id: 1 },
+        }
+      })
+  
+      const returnStatus = 404
+      const returnSuccess = false
+      const returnMessage = 'Missing refresh token'
+  
+      // Execute
+      const res = await request(app)
+        .post(`/auth/logout`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        
+        
+  
+      // Assert
+      expect(res.status).toBe(returnStatus)
+  
+      expect(typeof res.body.status).toBe('number')
+      expect(typeof res.body.success).toBe('boolean')
+      expect(typeof res.body.message).toBe('string')
+  
+      expect(res.body.status).toEqual(returnStatus)
+      expect(res.body.success).toEqual(returnSuccess)
+      expect(res.body.message).toEqual(returnMessage)
+      
+    })
+  
+    it('should return status 500 if the resource encounters any other issues', async () => {
+  
+      // Setup
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return { 
+          id: 1, 
+          token: 'wWQEQQEGYTG345456234',
+          created_at: '',
+          updated_at: ''      
+        }
+      })
+  
+      jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
+        return {
+          success: true,
+          message: 'refreshToken successfully removed'
+        }
+      })
+  
+      jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
+        return {
+          success: false,
+          message: 'There is a problem with the resource, please try again later'
+        }
+    })
+  
+      const returnStatus = 500
+      const returnSuccess = false
+      const returnMessage = 'There is a problem with the resource, please try again later'
+  
+      // Execute
+      const res = await request(app)
+        .post(`/auth/logout`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .set('Cookie', `jwt=${refreshToken}`)
+        .send({
+          refreshToken
+        })
+  
+      // Assert
+      expect(res.status).toBe(returnStatus)
+  
+      expect(typeof res.body.status).toBe('number')
+      expect(typeof res.body.success).toBe('boolean')
+      expect(typeof res.body.message).toBe('string')
+  
+      expect(res.body.status).toEqual(returnStatus)
+      expect(res.body.success).toEqual(returnSuccess)
+      expect(res.body.message).toEqual(returnMessage)
+      
+    })
+  
+  })
+
+  describe('loginUser', () => {
 
     /*
      * Steps to run before and after this test suite
@@ -55,7 +274,7 @@ describe('authController.loginUser', () => {
 
       const returnStatus = 200;
       const returnSuccess = true;
-      const returnBody = { accessToken: returnToken, refreshToken: returnToken };
+      const returnBody = { accessToken: returnToken,};
 
       // Mock any needed third party modules
       passport.authenticate = jest.fn((authType, callback) => () => {
@@ -63,7 +282,7 @@ describe('authController.loginUser', () => {
       });
 
       jest.spyOn(userModel, 'generateTokens').mockImplementation(() => {
-        return {accessToken: returnToken, refreshToken: returnToken};
+        return {accessToken: returnToken};
       });
 
       jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
@@ -412,9 +631,9 @@ describe('authController.loginUser', () => {
     
     });
 
-});
+  });
 
-describe('authController.createUser', () => {
+  describe('createUser', () => {
 
     /*
      * Steps to run before and after this test suite
@@ -1020,870 +1239,492 @@ describe('authController.createUser', () => {
   
     });
   
-});
+  });
 
-describe('authController.refreshToken', () => {
+  describe('refreshToken', () => {
 
-  beforeEach(() => {
-
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
-  it('should return status 200 and a valid access token with a valid refresh token', async () => {
-
-    // Setup
-    const mockedVerifiedRefreshPayload = { _id: 1, username: 'twatkins'}
-    //const refreshToken = '41234234-2341234234123-2341234234-2342341234'
-
-    const accessToken = '45345345-34534534513-3451334234-1341234234'
-    const refreshToken = '451344234-12344562456-25624556456-265245626'
-
-    const foundRefreshTokenData = {
-      id: 1,
-      userId: 1,
-      token: refreshToken,
-      created_at: '',
-      updated_at: ''
-    }
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementationOnce(() => {
-      return mockedVerifiedRefreshPayload;
+    beforeEach(() => {
+  
     })
-
-    jest.spyOn(userModel, 'generateTokens').mockImplementationOnce(() => {
-      return { accessToken, refreshToken }
+  
+    afterEach(() => {
+      jest.clearAllMocks()
     })
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementationOnce(() => {
-      return foundRefreshTokenData;
-    })
-
-    const returnStatus = 200;
-    const returnSuccess = true;
-    const returnMessage = 'New access token created';
-
-    // Execute
-    const result = await request(app)
-     .post(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.token).toBe('string')
-
-    expect(result.body.token).toEqual(accessToken)
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-  it('should return status 400 if supplied refresh token is not in use', async () => {
-
-    // Setup
-    const mockedVerifiedRefreshPayload = { _id: 1, username: 'twatkins'}
-    const refreshToken = '41234234-2341234234123-2341234234-2342341234'
-
-    const newAccessToken = '45345345-34534534513-3451334234-1341234234'
-    const newRefreshToken = '451344234-12344562456-25624556456-265245626'
-
-    const foundRefreshTokenData = false
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
-      return mockedVerifiedRefreshPayload;
-    })
-
-    jest.spyOn(userModel, 'generateTokens').mockImplementation(() => {
-      return { newAccessToken, newRefreshToken }
-    })
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    const returnStatus = 400;
-    const returnSuccess = false;
-    const returnMessage = 'Refresh token not in use, please login';
-
-    // Execute
-    const result = await request(app)
-     .post(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.token).toBe('string')
-
-    expect(result.body.token).toEqual('')
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-  it('should return status 400 if supplied refresh token is not valid', async () => {
-
-    // Setup
-    const mockedVerifiedRefreshPayload = false
-    const refreshToken = '41234234-2341234234123-2341234234-2342341234'
-
-    const newAccessToken = '45345345-34534534513-3451334234-1341234234'
-    const newRefreshToken = '451344234-12344562456-25624556456-265245626'
-
-    const foundRefreshTokenData = false
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
-      return mockedVerifiedRefreshPayload;
-    })
-
-    jest.spyOn(userModel, 'generateTokens').mockImplementation(() => {
-      return { newAccessToken, newRefreshToken }
-    })
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    const returnStatus = 400;
-    const returnSuccess = false;
-    const returnMessage = 'Not a valid refresh token, please login';
-
-    // Execute
-    const result = await request(app)
-     .post(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.token).toBe('string')
-
-    expect(result.body.token).toEqual('')
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-  it('should return status 400 if supplied refresh token is of the wrong format', async () => {
-
-    // Setup
-    const mockedVerifiedRefreshPayload = { _id: 1, username: 'twatkins'}
-    const refreshToken = 453456756623554
-
-    const newAccessToken = '45345345-34534534513-3451334234-1341234234'
-    const newRefreshToken = '451344234-12344562456-25624556456-265245626'
-
-    const foundRefreshTokenData = false
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
-      return mockedVerifiedRefreshPayload;
-    })
-
-    jest.spyOn(userModel, 'generateTokens').mockImplementation(() => {
-      return { newAccessToken, newRefreshToken }
-    })
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    const returnStatus = 400;
-    const returnSuccess = false;
-    const returnMessage = 'Wrong format for refresh token';
-
-    // Execute
-    const result = await request(app)
-     .post(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.token).toBe('string')
-
-    expect(result.body.token).toEqual('')
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-  it('should return status 404 if the refresh token is undefined', async () => {
-
-    // Setup
-    const mockedVerifiedRefreshPayload = {}
-    let refreshToken
-
-    let newAccessToken
-    let newRefreshToken
-
-    const foundRefreshTokenData = {}
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
-      return mockedVerifiedRefreshPayload;
-    })
-
-    jest.spyOn(userModel, 'generateTokens').mockImplementation(() => {
-      return { newAccessToken, newRefreshToken }
-    })
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    const returnStatus = 404;
-    const returnSuccess = false;
-    const returnMessage = 'Undefined refresh token';
-
-    // Execute
-    const result = await request(app)
-     .post(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.token).toBe('string')
-
-    expect(result.body.token).toEqual('')
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-  it('should return status 500 if there are other problems that the resource encounters', async () => {
-
-    // Setup
-    const mockedVerifiedRefreshPayload = { 
-      success: false,
-      message: 'There was a problem with the resource, please try again later' 
-    }
-    const refreshToken = '41234234-2341234234123-2341234234-2342341234'
-
-    const newAccessToken = ''
-    const newRefreshToken = ''
-
-    const foundRefreshTokenData = {
-      id: 1,
-      userId: 1,
-      token: refreshToken,
-      created_at: '',
-      updated_at: ''
-    }
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
-      return mockedVerifiedRefreshPayload;
-    })
-
-    jest.spyOn(userModel, 'generateTokens').mockImplementation(() => {
-      return { newAccessToken, newRefreshToken }
-    })
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    const returnStatus = 500;
-    const returnSuccess = false;
-    const returnMessage = 'There was a problem with the resource, please try again later';
-
-    // Execute
-    const result = await request(app)
-     .post(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.token).toBe('string')
-
-    expect(result.body.token).toEqual(newAccessToken)
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-})
-
-describe('authController.removeToken', () => {
-
-  beforeEach(() => {
-
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
-  it('should return status 201 and remove the refresh token from the assigned list', async () => {
-
-    // Setup
-    const refreshToken = '41234234-2341234234123-2341234234-2342341234'
-
-    const foundRefreshTokenData = {
-      id: 1,
-      userId: 1,
-      token: refreshToken,
-      created_at: '',
-      updated_at: ''
-    }
-
-    const removeTokenData = {
-      success: true,
-      message: 'refreshToken successfully removed'
-    }
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return removeTokenData;
-    })
-
-    const returnStatus = 201;
-    const returnSuccess = true;
-    const returnMessage = 'Successfully logged out';
-    const returnToken = '';
-
-    // Execute
-    const result = await request(app)
-     .delete(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.token).toBe('string')
-
-    expect(result.body.token).toEqual(returnToken)
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-  it('should return status 404 if no refresh token supplied', async () => {
-
-    // Setup
-    let refreshToken
-
-    const foundRefreshTokenData = {}
-
-    const removeTokenData = {}
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return removeTokenData;
-    })
-
-    const returnStatus = 404;
-    const returnSuccess = false;
-    const returnMessage = 'Undefined refresh token';
-    const returnToken = '';
-
-    // Execute
-    const result = await request(app)
-     .delete(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.success).toBe('boolean')
-    expect(typeof result.body.status).toBe('number')
-
-    expect(result.body.status).toEqual(returnStatus)
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-  it('should return status 404 if refresh token is not assigned', async () => {
-
-    // Setup
-    let refreshToken = '344234234234-4656855234-3452634-453453'
-
-    const foundRefreshTokenData = false
-
-    const removeTokenData = {}
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return removeTokenData;
-    })
-
-    const returnStatus = 404;
-    const returnSuccess = false;
-    const returnMessage = 'Refresh token not assigned';
-    const returnToken = '';
-
-    // Execute
-    const result = await request(app)
-     .delete(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.success).toBe('boolean')
-    expect(typeof result.body.status).toBe('number')
-
-    expect(result.body.status).toEqual(returnStatus)
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-  it('should return status 400 if the refresh token is in the wrong format', async () => {
-
-    // Setup
-    const refreshToken = 3453456467
-
-    const foundRefreshTokenData = {}
-
-    const removeTokenData = {}
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return removeTokenData;
-    })
-
-    const returnStatus = 400;
-    const returnSuccess = false;
-    const returnMessage = 'Wrong format for refresh token';
-    const returnToken = '';
-
-    // Execute
-    const result = await request(app)
-     .delete(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.success).toBe('boolean')
-    expect(typeof result.body.status).toBe('number')
-
-    expect(result.body.status).toEqual(returnStatus)
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-  it('should return status 400 if there was a problem removing the refresh token', async () => {
-
-    // Setup
-    const refreshToken = '3453456467-4545645635-53541345-453451345'
-
-    const foundRefreshTokenData = {
-      id: 1,
-      userId: 1,
-      token: refreshToken,
-      created_at: '',
-      updated_at: ''
-    }
-
-    const removeTokenData = {
-      success: false,
-      message: 'No refresh tokens were found matching supplied data'
-  }
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return removeTokenData;
-    })
-
-    const returnStatus = 400;
-    const returnSuccess = false;
-    const returnMessage = 'No refresh tokens were found matching supplied data';
-    const returnToken = '';
-
-    // Execute
-    const result = await request(app)
-     .delete(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.success).toBe('boolean')
-    expect(typeof result.body.status).toBe('number')
-
-    expect(result.body.status).toEqual(returnStatus)
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-  it('should return status 500 if the resource encounters any other problems', async () => {
-
-    // Setup
-    const refreshToken = '41234234-2341234234123-2341234234-2342341234'
-
-    const foundRefreshTokenData = {
-      success: false,
-      message: 'There was a problem with the resource, please try again later'
-    }
-
-    const removeTokenData = {}
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return foundRefreshTokenData;
-    })
-
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return removeTokenData;
-    })
-
-    const returnStatus = 500;
-    const returnSuccess = false;
-    const returnMessage = 'There was a problem with the resource, please try again later';
-    const returnToken = '';
-
-    // Execute
-    const result = await request(app)
-     .delete(`/auth/refresh-token`)
-     .send({
-      refreshToken
-     })
-
-    // Assert
-    expect(result.status).toBe(returnStatus)
-
-    expect(typeof result.body.message).toBe('string')
-    expect(typeof result.body.success).toBe('boolean')
-    expect(typeof result.body.status).toBe('number')
-
-    expect(result.body.status).toEqual(returnStatus)
-    expect(result.body.success).toEqual(returnSuccess)
-    expect(result.body.message).toEqual(returnMessage)
-
-  })
-
-})
-
-describe('logoutUser', () => {
-
-  beforeEach(async () => {
-
-    accessToken = '245742534-45734565345-2454345345345'
-    refreshToken = '34535434-34513413453-23452345345-34534-897'
-
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  })
-
-  it('should return status 200 and log out a user and remove the associated refresh token assigned', async () => {
-
-    // Setup
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return { 
-        id: 1, 
-        token: 'wWQEQQEGYTG345456234',
+  
+    it('should return status 200 and a valid access token with a valid refresh token', async () => {
+  
+      // Setup
+      const mockedVerifiedRefreshPayload = { _id: 1, username: 'twatkins'}
+      //const refreshToken = '41234234-2341234234123-2341234234-2342341234'
+  
+      const accessToken = '45345345-34534534513-3451334234-1341234234'
+      const refreshToken = '451344234-12344562456-25624556456-265245626'
+  
+      const foundRefreshTokenData = {
+        id: 1,
+        userId: 1,
+        token: refreshToken,
         created_at: '',
-        updated_at: ''      
+        updated_at: ''
       }
+  
+      jest.spyOn(userModel, 'verifyRefreshToken').mockImplementationOnce(() => {
+        return mockedVerifiedRefreshPayload;
+      })
+  
+      jest.spyOn(userModel, 'generateTokens').mockImplementationOnce(() => {
+        return { accessToken, refreshToken }
+      })
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementationOnce(() => {
+        return foundRefreshTokenData;
+      })
+  
+      const returnStatus = 200;
+      const returnSuccess = true;
+      const returnMessage = 'New access token created';
+  
+      // Execute
+      const result = await request(app)
+       .post(`/auth/refresh-token`)
+       .set('Cookie', `jwt=${accessToken}`)
+  
+      // Assert
+      expect(result.status).toBe(returnStatus)
+  
+      expect(typeof result.body.message).toBe('string')
+      expect(typeof result.body.token).toBe('string')
+  
+      expect(result.body.token).toEqual(accessToken)
+      expect(result.body.success).toEqual(returnSuccess)
+      expect(result.body.message).toEqual(returnMessage)
+  
     })
+  
+    it('should return status 400 if supplied refresh token is not in use', async () => {
+  
+      // Setup
+      const mockedVerifiedRefreshPayload = { _id: 1, username: 'twatkins'}
+      const refreshToken = '41234234-2341234234123-2341234234-2342341234'
+  
+      const newAccessToken = '45345345-34534534513-3451334234-1341234234'
+      const newRefreshToken = '451344234-12344562456-25624556456-265245626'
+  
+      const foundRefreshTokenData = false
+  
+      jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
+        return mockedVerifiedRefreshPayload;
+      })
+  
+      jest.spyOn(userModel, 'generateTokens').mockImplementation(() => {
+        return { newAccessToken, newRefreshToken }
+      })
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return foundRefreshTokenData;
+      })
+  
+      const returnStatus = 400;
+      const returnSuccess = false;
+      const returnMessage = 'Refresh token not in use, please login';
+  
+      // Execute
+      const result = await request(app)
+       .post(`/auth/refresh-token`)
+       .set('Cookie', `jwt=${accessToken}`)
+  
+      // Assert
+      expect(result.status).toBe(returnStatus)
+  
+      expect(typeof result.body.message).toBe('string')
+      expect(typeof result.body.token).toBe('string')
+  
+      expect(result.body.token).toEqual('')
+      expect(result.body.success).toEqual(returnSuccess)
+      expect(result.body.message).toEqual(returnMessage)
+  
+    })
+  
+    it('should return status 400 if supplied refresh token is not valid', async () => {
+  
+      // Setup
+      const mockedVerifiedRefreshPayload = false
+      const refreshToken = '41234234-2341234234123-2341234234-2342341234'
+  
+      const newAccessToken = '45345345-34534534513-3451334234-1341234234'
+      const newRefreshToken = '451344234-12344562456-25624556456-265245626'
+  
+      const foundRefreshTokenData = false
+  
+      jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
+        return mockedVerifiedRefreshPayload;
+      })
+  
+      jest.spyOn(userModel, 'generateTokens').mockImplementation(() => {
+        return { newAccessToken, newRefreshToken }
+      })
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return foundRefreshTokenData;
+      })
+  
+      const returnStatus = 400;
+      const returnSuccess = false;
+      const returnMessage = 'Not a valid refresh token, please login';
+  
+      // Execute
+      const result = await request(app)
+       .post(`/auth/refresh-token`)
+       .set('Cookie', `jwt=twelve`)
+  
+      // Assert
+      expect(result.status).toBe(returnStatus)
+  
+      expect(typeof result.body.message).toBe('string')
+      expect(typeof result.body.token).toBe('string')
+  
+      expect(result.body.token).toEqual('')
+      expect(result.body.success).toEqual(returnSuccess)
+      expect(result.body.message).toEqual(returnMessage)
+  
+    })
+  
+  
+    it('should return status 404 if the refresh token is undefined', async () => {
+  
+      // Setup
+      const mockedVerifiedRefreshPayload = {}
+      let refreshToken
+  
+      let newAccessToken
+      let newRefreshToken
+  
+      const foundRefreshTokenData = {}
+  
+      jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
+        return mockedVerifiedRefreshPayload;
+      })
+  
+      jest.spyOn(userModel, 'generateTokens').mockImplementation(() => {
+        return { newAccessToken, newRefreshToken }
+      })
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return foundRefreshTokenData;
+      })
+  
+      const returnStatus = 404;
+      const returnSuccess = false;
+      const returnMessage = 'Invalid refresh token, please login';
+  
+      // Execute
+      const result = await request(app)
+       .post(`/auth/refresh-token`)
+  
+      // Assert
+      expect(result.status).toBe(returnStatus)
+  
+      expect(typeof result.body.message).toBe('string')
+      expect(typeof result.body.token).toBe('string')
+  
+      expect(result.body.token).toEqual('')
+      expect(result.body.success).toEqual(returnSuccess)
+      expect(result.body.message).toEqual(returnMessage)
+  
+    })
+  
+    it('should return status 500 if there are other problems that the resource encounters', async () => {
+  
+      // Setup
+      const mockedVerifiedRefreshPayload = { 
+        success: false,
+        message: 'There was a problem with the resource, please try again later' 
+      }
+      const refreshToken = '41234234-2341234234123-2341234234-2342341234'
+  
+      const newAccessToken = ''
+      const newRefreshToken = ''
+  
+      const foundRefreshTokenData = {
+        id: 1,
+        userId: 1,
+        token: refreshToken,
+        created_at: '',
+        updated_at: ''
+      }
+  
+      jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
+        return mockedVerifiedRefreshPayload;
+      })
+  
+      jest.spyOn(userModel, 'generateTokens').mockImplementation(() => {
+        return { newAccessToken, newRefreshToken }
+      })
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return foundRefreshTokenData;
+      })
+  
+      const returnStatus = 500;
+      const returnSuccess = false;
+      const returnMessage = 'There was a problem with the resource, please try again later';
+  
+      // Execute
+      const result = await request(app)
+       .post(`/auth/refresh-token`)
+       .set('Cookie', `jwt=${accessToken}`)
+  
+      // Assert
+      expect(result.status).toBe(returnStatus)
+  
+      expect(typeof result.body.message).toBe('string')
+      expect(typeof result.body.token).toBe('string')
+  
+      expect(result.body.token).toEqual(newAccessToken)
+      expect(result.body.success).toEqual(returnSuccess)
+      expect(result.body.message).toEqual(returnMessage)
+  
+    })
+  
+  })
 
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return {
+  describe('removeToken', () => {
+
+    beforeEach(() => {
+  
+      
+    })
+  
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+  
+    it('should return status 201 and remove the refresh token from the assigned list', async () => {
+  
+      // Setup
+      const refreshToken = '41234234-2341234234123-2341234234-2342341234'
+  
+      const foundRefreshTokenData = {
+        id: 1,
+        userId: 1,
+        token: refreshToken,
+        created_at: '',
+        updated_at: ''
+      }
+  
+      const removeTokenData = {
         success: true,
         message: 'refreshToken successfully removed'
       }
-    })
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
-      return {
-        id: 1,
-        username: 'sbilly@sport.net',
-        forename: 'Sport',
-        surname: 'Billy',
-        roles: 'Customer'
-      }
-    })
-
-    const returnStatus = 200
-    const returnSuccess = true
-    const returnMessage = 'Successfully logged out'
-
-    // Execute
-    const res = await request(app)
-      .post(`/auth/logout`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({
-        refreshToken
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return foundRefreshTokenData;
       })
-
-    // Assert
-    expect(res.status).toBe(returnStatus)
-
-    expect(typeof res.body.status).toBe('number')
-    expect(typeof res.body.success).toBe('boolean')
-    expect(typeof res.body.message).toBe('string')
-
-    expect(res.body.status).toEqual(returnStatus)
-    expect(res.body.success).toEqual(returnSuccess)
-    expect(res.body.message).toEqual(returnMessage)
-    
-  })
-
-  it('should return status 200 and send a logout message if no refreshToken is found assigned to a user', async () => {
-
-    // Setup
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return false
+  
+      jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
+        return removeTokenData;
+      })
+  
+      const returnStatus = 200;
+      const returnSuccess = true;
+      const returnMessage = 'Successfully logged out';
+      const returnToken = '';
+  
+      // Execute
+      const result = await request(app)
+       .delete(`/auth/refresh-token`)
+       .set('Cookie', `jwt=${refreshToken}`)
+  
+      // Assert
+      expect(result.status).toBe(returnStatus)
+  
+      expect(typeof result.body.message).toBe('string')
+      expect(typeof result.body.token).toBe('string')
+  
+      expect(result.body.token).toEqual(returnToken)
+      expect(result.body.success).toEqual(returnSuccess)
+      expect(result.body.message).toEqual(returnMessage)
+  
     })
-
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return {
+  
+    it('should return status 404 if no refresh token supplied', async () => {
+  
+      // Setup
+      const foundRefreshTokenData = {}
+  
+      const removeTokenData = {}
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return foundRefreshTokenData;
+      })
+  
+      jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
+        return removeTokenData;
+      })
+  
+      const returnStatus = 404;
+      const returnSuccess = false;
+      const returnMessage = 'No refresh token found';
+      const returnToken = '';
+  
+      // Execute
+      const result = await request(app)
+       .delete(`/auth/refresh-token`)
+       
+  
+      // Assert
+      expect(result.status).toBe(returnStatus)
+  
+      expect(typeof result.body.message).toBe('string')
+      expect(typeof result.body.success).toBe('boolean')
+      expect(typeof result.body.status).toBe('number')
+  
+      expect(result.body.status).toEqual(returnStatus)
+      expect(result.body.success).toEqual(returnSuccess)
+      expect(result.body.message).toEqual(returnMessage)
+  
+    })
+  
+    it('should return status 404 if refresh token is not assigned', async () => {
+  
+      // Setup
+      let refreshToken = '344234234234-4656855234-3452634-453453'
+  
+      const foundRefreshTokenData = false
+  
+      const removeTokenData = {}
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return foundRefreshTokenData;
+      })
+  
+      jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
+        return removeTokenData;
+      })
+  
+      const returnStatus = 404;
+      const returnSuccess = false;
+      const returnMessage = 'Refresh token not assigned';
+      const returnToken = '';
+  
+      // Execute
+      const result = await request(app)
+       .delete(`/auth/refresh-token`)
+       .set('Cookie', `jwt=${refreshToken}`)
+  
+      // Assert
+      expect(result.status).toBe(returnStatus)
+  
+      expect(typeof result.body.message).toBe('string')
+      expect(typeof result.body.success).toBe('boolean')
+      expect(typeof result.body.status).toBe('number')
+  
+      expect(result.body.status).toEqual(returnStatus)
+      expect(result.body.success).toEqual(returnSuccess)
+      expect(result.body.message).toEqual(returnMessage)
+  
+    })
+  
+    it('should return status 400 if there was a problem removing the refresh token', async () => {
+  
+      // Setup
+      const refreshToken = '3453456467-4545645635-53541345-453451345'
+  
+      const foundRefreshTokenData = {
+        id: 1,
+        userId: 1,
+        token: refreshToken,
+        created_at: '',
+        updated_at: ''
+      }
+  
+      const removeTokenData = {
         success: false,
         message: 'No refresh tokens were found matching supplied data'
-      }
-    })
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
-      return {
-        id: 1,
-        username: 'sbilly@sport.net',
-        forename: 'Sport',
-        surname: 'Billy',
-        roles: 'Customer'
-      }
-    })
-
-    const returnStatus = 200
-    const returnSuccess = true
-    const returnMessage = 'Successfully logged out'
-
-    // Execute
-    const res = await request(app)
-      .post(`/auth/logout`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({
-        refreshToken
+    }
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return foundRefreshTokenData;
       })
-
-    // Assert
-    expect(res.status).toBe(returnStatus)
-
-    expect(typeof res.body.status).toBe('number')
-    expect(typeof res.body.success).toBe('boolean')
-    expect(typeof res.body.message).toBe('string')
-
-    expect(res.body.status).toEqual(returnStatus)
-    expect(res.body.success).toEqual(returnSuccess)
-    expect(res.body.message).toEqual(returnMessage)
-    
-  })
-
-  it('should return status 404 if no refresh token is sent', async () => {
-
-    // Setup
-    let missingToken
-
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return { 
-        id: 1, 
-        token: 'wWQEQQEGYTG345456234',
-        created_at: '',
-        updated_at: ''      
-      }
-    })
-
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return {
-        success: true,
-        message: 'refreshToken successfully removed'
-      }
-    })
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
-      return {
-        id: 1,
-        username: 'sbilly@sport.net',
-        forename: 'Sport',
-        surname: 'Billy',
-        roles: 'Customer'
-      }
-    })
-
-    const returnStatus = 404
-    const returnSuccess = false
-    const returnMessage = 'Missing refresh token'
-
-    // Execute
-    const res = await request(app)
-      .post(`/auth/logout`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({
-        refreshToken: missingToken
+  
+      jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
+        return removeTokenData;
       })
-
-    // Assert
-    expect(res.status).toBe(returnStatus)
-
-    expect(typeof res.body.status).toBe('number')
-    expect(typeof res.body.success).toBe('boolean')
-    expect(typeof res.body.message).toBe('string')
-
-    expect(res.body.status).toEqual(returnStatus)
-    expect(res.body.success).toEqual(returnSuccess)
-    expect(res.body.message).toEqual(returnMessage)
-    
-  })
-
-  it('should return status 400 if refresh token is in the wrong format', async () => {
-
-    // Setup
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return { 
-        id: 1, 
-        token: 'wWQEQQEGYTG345456234',
-        created_at: '',
-        updated_at: ''      
-      }
+  
+      const returnStatus = 400;
+      const returnSuccess = false;
+      const returnMessage = 'No refresh tokens were found matching supplied data';
+      const returnToken = '';
+  
+      // Execute
+      const result = await request(app)
+       .delete(`/auth/refresh-token`)
+       .set('Cookie', `jwt=${refreshToken}`)
+  
+      // Assert
+      expect(result.status).toBe(returnStatus)
+  
+      expect(typeof result.body.message).toBe('string')
+      expect(typeof result.body.success).toBe('boolean')
+      expect(typeof result.body.status).toBe('number')
+  
+      expect(result.body.status).toEqual(returnStatus)
+      expect(result.body.success).toEqual(returnSuccess)
+      expect(result.body.message).toEqual(returnMessage)
+  
     })
-
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return {
-        success: true,
-        message: 'refreshToken successfully removed'
-      }
-    })
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
-      return {
-        id: 1,
-        username: 'sbilly@sport.net',
-        forename: 'Sport',
-        surname: 'Billy',
-        roles: 'Customer'
-      }
-    })
-
-    const returnStatus = 400
-    const returnSuccess = false
-    const returnMessage = 'Refresh token is not in the correct format'
-
-    // Execute
-    const res = await request(app)
-      .post(`/auth/logout`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({
-        refreshToken: 5643933874934
-      })
-
-    // Assert
-    expect(res.status).toBe(returnStatus)
-
-    expect(typeof res.body.status).toBe('number')
-    expect(typeof res.body.success).toBe('boolean')
-    expect(typeof res.body.message).toBe('string')
-
-    expect(res.body.status).toEqual(returnStatus)
-    expect(res.body.success).toEqual(returnSuccess)
-    expect(res.body.message).toEqual(returnMessage)
-    
-  })
-
-  it('should return status 500 if the resource encounters any other issues', async () => {
-
-    // Setup
-    jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
-      return { 
-        id: 1, 
-        token: 'wWQEQQEGYTG345456234',
-        created_at: '',
-        updated_at: ''      
-      }
-    })
-
-    jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
-      return {
-        success: true,
-        message: 'refreshToken successfully removed'
-      }
-    })
-
-    jest.spyOn(userModel, 'verifyRefreshToken').mockImplementation(() => {
-      return {
+  
+    it('should return status 500 if the resource encounters any other problems', async () => {
+  
+      // Setup
+      const refreshToken = '41234234-2341234234123-2341234234-2342341234'
+  
+      const foundRefreshTokenData = {
         success: false,
-        message: 'There is a problem with the resource, please try again later'
+        message: 'There was a problem with the resource, please try again later'
       }
-  })
-
-    const returnStatus = 500
-    const returnSuccess = false
-    const returnMessage = 'There is a problem with the resource, please try again later'
-
-    // Execute
-    const res = await request(app)
-      .post(`/auth/logout`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({
-        refreshToken
+  
+      const removeTokenData = {}
+  
+      jest.spyOn(tokenModel, 'findOne').mockImplementation(() => {
+        return foundRefreshTokenData;
       })
-
-    // Assert
-    expect(res.status).toBe(returnStatus)
-
-    expect(typeof res.body.status).toBe('number')
-    expect(typeof res.body.success).toBe('boolean')
-    expect(typeof res.body.message).toBe('string')
-
-    expect(res.body.status).toEqual(returnStatus)
-    expect(res.body.success).toEqual(returnSuccess)
-    expect(res.body.message).toEqual(returnMessage)
-    
+  
+      jest.spyOn(tokenModel, 'removeOne').mockImplementation(() => {
+        return removeTokenData;
+      })
+  
+      const returnStatus = 500;
+      const returnSuccess = false;
+      const returnMessage = 'There was a problem with the resource, please try again later';
+      const returnToken = '';
+  
+      // Execute
+      const result = await request(app)
+       .delete(`/auth/refresh-token`)
+       .set('Cookie', `jwt=${refreshToken}`)
+  
+      // Assert
+      expect(result.status).toBe(returnStatus)
+  
+      expect(typeof result.body.message).toBe('string')
+      expect(typeof result.body.success).toBe('boolean')
+      expect(typeof result.body.status).toBe('number')
+  
+      expect(result.body.status).toEqual(returnStatus)
+      expect(result.body.success).toEqual(returnSuccess)
+      expect(result.body.message).toEqual(returnMessage)
+  
+    })
+  
   })
 
 })
+
+
+
+
+
+
+
+

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const morgan = require('morgan');
 const rfs = require('rotating-file-stream');
 const path = require('path');
 const bodyParser = require('body-parser');
+const cookieParser = require('cookie-parser');
 
 /*
  * Configure the app
@@ -17,6 +18,7 @@ const bodyParser = require('body-parser');
  app.use(express.json()); 
  app.use(express.urlencoded({ extended: true }));
  app.use(cors());
+ app.use(cookieParser());
  app.use(passport.initialize());
  require('./config/passport');
 

--- a/middlewares/verifyMiddleware.js
+++ b/middlewares/verifyMiddleware.js
@@ -12,7 +12,7 @@ const checkRoles = (roles) => (req, res, next) => {
 
     /* Check the specified roles against any the user has */
     const rolesFound = roles.includes(req?.user?.roles);
-    console.log(rolesFound)
+    
     if(!rolesFound){
         return next({
             status: 403,
@@ -40,14 +40,14 @@ const checkToken = async (req,res,next) => {
                         message: 'Your access token has expired, please login'
                     })
                 } else if(info?.message === 'No auth token'){
-                    console.log('=== DEBUG ===: ', err, user, info)
+                    
                     return res.status(401).json({
                         status: 401,
                         success: false,
                         message: 'You are not authorized to access this resource, please login'
                     })
                 } else {
-                    console.log(info)
+                    
                     return next(info?.message)
                 }
             } else {
@@ -59,7 +59,7 @@ const checkToken = async (req,res,next) => {
                     req.user = user
                 }
                 
-                console.log(req.user)
+                
                 return next()
             }
         }

--- a/models/pantryModel.js
+++ b/models/pantryModel.js
@@ -294,7 +294,7 @@ const listAll = async () => {
     /* We only wish to have the errors specific to the model reported back others are caught as
     a generic error */
     let message;
-    console.log(e)
+    
     if(e.name === 'PANTRYMODEL_ERROR'){
       message = e.message;
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1521,6 +1521,22 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "bcrypt": "^5.0.1",
     "body-parser": "^1.20.0",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.18.1",
     "jest-cli": "^29.1.2",


### PR DESCRIPTION
To make the site a little more secure, we should send the refresh token in a httpOnly cookie