### PR TITLE
checkRoles is case sensitive

### DIFF
--- a/middlewares/verifyMiddleware.js
+++ b/middlewares/verifyMiddleware.js
@@ -12,8 +12,11 @@ const checkRoles = (roles) => (req, res, next) => {
         })
     }
 
-    /* Check the specified roles against any the user has */
-    const rolesFound = roles.includes(req?.user?.roles);
+    /* Check the specified roles against any the user has, convert both to lowercase before comparing */
+    let userRole = req.user.roles.toLowerCase()
+    
+    //const rolesFound = roles.includes(userRole);
+    const rolesFound = roles.some(role => role.toLowerCase() == userRole)
     
     if(!rolesFound){
         return next({


### PR DESCRIPTION
When comparing a routes allowed role to the user role the comparison is case sensitive. 

This means if a role is set as admin for the user but Admin for the route it will not match.

This PR aims to correct this by making sure both sides of the comparison are lowercase