### PR TITLE
Can overwrite rating when updating a recipe

### DIFF
--- a/controllers/recipesController.js
+++ b/controllers/recipesController.js
@@ -1329,7 +1329,7 @@ const update = async (req, res, next) => {
                 message: 'Wrong format for cook_time'
             }
         }
-
+        /*
         if(!req.body.rating || req.body.rating === undefined){
             throw {
                 status: 400,
@@ -1345,6 +1345,7 @@ const update = async (req, res, next) => {
                 message: 'Wrong format for rating'
             }
         }
+        */
 
         /* Actually update the desired record now */
         const result = await recipeModel.update({
@@ -1355,8 +1356,7 @@ const update = async (req, res, next) => {
             servings: parseInt(req.body.servings),
             calories_per_serving: parseInt(req.body.calories_per_serving),
             prep_time: parseInt(req.body.prep_time),
-            cook_time: parseInt(req.body.cook_time),
-            rating: parseInt(req.body.rating)
+            cook_time: parseInt(req.body.cook_time)
         });
 
         if(!result || result.success === false){

--- a/models/recipeModel.js
+++ b/models/recipeModel.js
@@ -351,13 +351,14 @@ const update = async recipe => {
       }
     }
     
-
+    /*
     if(!validation.validator(recipe.rating, 'number')){
       throw {
         name: 'RECIPEMODEL_ERROR',
         message: 'Validation failed for rating'
       }
     }
+    */
     
 
     /* Update the specifed record with the new values passed in */
@@ -373,8 +374,7 @@ const update = async recipe => {
           servings: recipe.servings,
           calories_per_serving: recipe.calories_per_serving,
           prep_time: recipe.prep_time,
-          cook_time: recipe.cook_time,
-          rating: recipe.rating
+          cook_time: recipe.cook_time
         })
         .where('id', recipe.recipeId);
       


### PR DESCRIPTION
All users once logged in are able to set the rating of a recipe to anything they want.

This PR covers the removal of rating from the recipeModel update method preserving any existing rating it has