### PR TITLE
JWT token is not being passed from front end to backend

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -123,7 +123,8 @@ passport.use(
         ExtractJWT.fromUrlQueryParameter('secret_token'),
         ExtractJWT.fromHeader('auth_token'),
         ExtractJWT.fromAuthHeaderAsBearerToken(),
-        ExtractJWT.fromAuthHeaderWithScheme('Authentication')
+        ExtractJWT.fromAuthHeaderWithScheme('Authentication'),
+        ExtractJWT.fromHeader('token')
       ])
     },
     /* Callback used to process the strategy */

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -147,9 +147,13 @@ const loginUser = async (req, res, next) => {
                     })
                 }
 
-                return res.cookie('jwt', refreshToken, { httpOnly: true, secure: false })
-                 .status(200)
-                 .json({ accessToken})
+                const cookieOptions = {
+                    httpOnly: true,
+                    secure: false, 
+                }
+
+                res.cookie('jwt', refreshToken, cookieOptions);
+                res.status(200).json({ accessToken });
                 //return res.json({ accessToken, refreshToken });
 
             });
@@ -478,9 +482,9 @@ const logoutUser = async (req, res, next) => {
     const moduleMethod = 'logoutUser';
 
     try{
-        
+
         if(!req.cookies['jwt']){
-            res.status(404).json({
+            return res.status(404).json({
                 status: 404,
                 success: false,
                 message: 'Missing refresh token'
@@ -515,6 +519,7 @@ const logoutUser = async (req, res, next) => {
          })
 
     } catch(e) {
+       
         /* Log out the issue(s) */
         appLogger.logMessage(
             'error', 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const passport = require('passport');
 const morgan = require('morgan');
 const rfs = require('rotating-file-stream');
 const path = require('path');
-const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 
 /*
@@ -17,8 +16,13 @@ const cookieParser = require('cookie-parser');
  */
  app.use(express.json()); 
  app.use(express.urlencoded({ extended: true }));
- app.use(cors());
  app.use(cookieParser());
+ app.use(cors({
+  //origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
+  origin: 'http://localhost:3000',
+  credentials: true,
+  allowedHeaders: "authorisation,Authorisation,Content-Type,content-type,Content-type,token"
+ }));
  app.use(passport.initialize());
  require('./config/passport');
 

--- a/middlewares/verifyMiddleware.js
+++ b/middlewares/verifyMiddleware.js
@@ -13,10 +13,10 @@ const checkRoles = (roles) => (req, res, next) => {
     }
 
     /* Check the specified roles against any the user has, convert both to lowercase before comparing */
-    let userRole = req.user.roles.toLowerCase()
+    let userRole = req.user.roles
     
     //const rolesFound = roles.includes(userRole);
-    const rolesFound = roles.some(role => role.toLowerCase() == userRole)
+    const rolesFound = roles.some(role => role.toLowerCase() == userRole.toLowercase)
     
     if(!rolesFound){
         return next({

--- a/middlewares/verifyMiddleware.js
+++ b/middlewares/verifyMiddleware.js
@@ -38,6 +38,7 @@ const checkToken = async (req,res,next) => {
         'jwt',
         { session: false },
         async (err, user, info) => {
+         
             if(err || !user){
                 if(info?.message === 'jwt expired'){
                     return res.status(401).json({ 
@@ -63,6 +64,7 @@ const checkToken = async (req,res,next) => {
                  * Use the userModel to retrieve the data
                  */
                 let userid = user.user ? user.user.id : user.id;
+                
                 const foundUser = await userModel.findById(userid)
                 
                 /* Assign the found user to the req object */
@@ -76,7 +78,7 @@ const checkToken = async (req,res,next) => {
                     })
                 }
                 
-                return next()
+               return next()
 
             }
 


### PR DESCRIPTION
When logging in to the admin portion of the app our backend produces the correct refreshToken inside a httpOnly cookie and sends to back as part of the response.

However, now matter what is tried the system is not sending the cookie back automatically with the request and as such the logout functionality produces an error and we end up logged in still.