### PR TITLE
Change upload list return status code

### DIFF
--- a/controllers/uploadController.js
+++ b/controllers/uploadController.js
@@ -205,9 +205,9 @@ const list = async (req, res, next) => {
         }
 
         if(result?.results?.length < 1){
-            return res.status(404).json({
+            return res.status(204).json({
                 success: false,
-                status: 404,
+                status: 204,
                 message: 'There were no records found',
                 results: [],
                 pagination: {


### PR DESCRIPTION
Currently the API returns 404 if no uploaded files match the API request from the client.

It should really be 204 as this better indicates that the route to the API was good it's just there was no data returned.